### PR TITLE
Support to build in the recent mingw environment

### DIFF
--- a/windows/rsrc.rc
+++ b/windows/rsrc.rc
@@ -19,6 +19,7 @@
 
 #include "windef.h"
 #include "winbase.h"
+#include "wingdi.h"
 #include "winuser.h"
 #include "winver.h"
 #include "main.h"


### PR DESCRIPTION
In the recent mingw environment, this patch is needed for defining DS_MODALFRAME etc.
