### PR TITLE
To show a filedescription on the file property.

### DIFF
--- a/windows/rsrc.rc
+++ b/windows/rsrc.rc
@@ -37,6 +37,10 @@ BEGIN
             VALUE "FileDescription", "LilyPad editor for LilyPond"
         END
     END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0
+    END
 END
 
 ID_ACCEL ACCELERATORS


### PR DESCRIPTION
This patch can show a filedescription on the property of lilypad.exe file.
