### PR TITLE
Separate object file name

### DIFF
--- a/windows/Make.rules.in
+++ b/windows/Make.rules.in
@@ -107,16 +107,25 @@ conf_manext     = 5
 CLEAN_FILES     = *.o *.a *.so *.ln *.$(LIBEXT) \\\#*\\\# *~ *% .\\\#* *.bak *.orig *.rej \
                   *.flc *.spec.c *.dbg.c *.tab.c *.tab.h @LEX_OUTPUT_ROOT@.c core
 
+ifeq ($(MODULE),lilypad-ascii.exe)
+OBJS = $(C_SRCS:.c=.ansi.o) $(EXTRA_OBJS)
+
+RCOBJS = $(RC_SRCS:.rc=.ansi.res.o)
+else
 OBJS = $(C_SRCS:.c=.o) $(EXTRA_OBJS)
 
 RCOBJS = $(RC_SRCS:.rc=.res.o)
+endif
 LINTS  = $(C_SRCS:.c=.ln)
 
 # Implicit rules
 
-.SUFFIXES: .mc .rc .mc.rc .res .res.o .spec .spec.c .idl .tlb .h .ok .sfd .ttf
+.SUFFIXES: .mc .rc .mc.rc .res .res.o .spec .spec.c .idl .tlb .h .ok .sfd .ttf .ansi.o .ansi.res.o
 
 .c.o:
+	$(CC) -c $(ALLCFLAGS) -o $@ $<
+
+.c.ansi.o:
 	$(CC) -c $(ALLCFLAGS) -o $@ $<
 
 .s.o:
@@ -126,6 +135,9 @@ LINTS  = $(C_SRCS:.c=.ln)
 	$(LDPATH) $(WMC) -i -U -H /dev/null -o $@ $<
 
 .rc.res.o:
+	$(LDPATH) $(RC) $(RCFLAGS) -fo$@ $<
+
+.rc.ansi.res.o:
 	$(LDPATH) $(RC) $(RCFLAGS) -fo$@ $<
 
 .res.res.o:

--- a/windows/Makefile.in
+++ b/windows/Makefile.in
@@ -30,12 +30,15 @@ ifeq ($(MODULE),lilypad.exe)
 
 all: lilypad-ascii.exe
 install:: install-lilypad-ascii
+clean:: clean-lilypad-ascii
 
 lilypad-ascii.exe: lilypad.exe
-	rm -f $(OBJS)
 	$(MAKE) MODULE=$@ CPPFLAGS=-UUNICODE
 	touch lilypad.exe
 endif
 
 install-lilypad-ascii:
 	$(MAKE) MODULE=lilypad-ascii.exe install
+
+clean-lilypad-ascii:
+	$(MAKE) MODULE=lilypad-ascii.exe clean


### PR DESCRIPTION
Object file names are separated by UNICODE version and ANSI version.
In the case of the same file names, the ANSI version object files
may be used for building UNICODE version "lilypad.exe".
