### PR TITLE
Bugfix: NULL termination

### DIFF
--- a/windows/dialog.c
+++ b/windows/dialog.c
@@ -228,9 +228,8 @@ void DoOpenFile(__LPCWSTR szFileName)
 	ShowLastError();
 	return;
     }
-    size++;
 
-    pTemp = HeapAlloc(GetProcessHeap(), 0, size);
+    pTemp = HeapAlloc(GetProcessHeap(), 0, size + 1);
     if (!pTemp)
     {
 	CloseHandle(hFile);


### PR DESCRIPTION
I found that a NULL termination may fail
when I'm making UTF-8 encoding file reading and writing support.
